### PR TITLE
split on unicode words for improved inline highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
 ]
 
 [[package]]
@@ -981,6 +982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 dependencies = [
  "bstr",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { version = "1.0", default-features = false, features = ["std"] }
 harmonia-store-aterm = { git = "https://github.com/nix-community/harmonia", branch = "nix-2.34" }
 harmonia-store-core = { git = "https://github.com/nix-community/harmonia", branch = "nix-2.34" }
 harmonia-utils-hash = { git = "https://github.com/nix-community/harmonia", branch = "nix-2.34" }
-similar = { version = "3.1", features = ["bytes", "text", "inline"], default-features = false }
+similar = { version = "3.1", features = ["bytes", "text", "inline", "unicode"], default-features = false }
 tempfile = { version = "3.27", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/render.rs
+++ b/src/render.rs
@@ -494,7 +494,14 @@ impl Renderer {
             }
             for op in group {
                 if self.inline_highlight {
-                    for change in diff.iter_inline_changes(op) {
+                    // matching on UnicodeWords better tokenizes words, paths, and other
+                    // non-space-delimited items, which gets us much more reliable inline
+                    // highlights
+                    for change in diff.iter_inline_changes_with_options(
+                        op,
+                        *similar::InlineChangeOptions::new()
+                            .mode(similar::InlineChangeMode::UnicodeWords),
+                    ) {
                         let (color, sign): (&[u8], &[u8]) = match change.tag() {
                             ChangeTag::Delete => (self.red(), b"- "),
                             ChangeTag::Insert => (self.green(), b"+ "),

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -5,6 +5,29 @@ use std::process::Command;
 mod common;
 use common::setup_nix_env;
 
+// Normalize store paths and hashes that have readable escape characters for consistent snapshots
+fn normalize_readable_nix_output(output: &str, store_dir: &str) -> String {
+    // Replace custom store path with /nix/store
+    let mut normalized = output.replace(store_dir, "/nix/store");
+
+    // Replace all hashes with "HASH"
+
+    // match against the file path diffs, which are never inline highlighted
+    let re = regex::Regex::new(r"^<red>\-\-\- /nix/store/[a-z0-9]{32}-").unwrap();
+    normalized = re
+        .replace_all(&normalized, r"<red>--- /nix/store/HASH-")
+        .to_string();
+
+    let re = regex::Regex::new(r"<grn>\+\+\+ /nix/store/[a-z0-9]{32}-").unwrap();
+    normalized = re
+        .replace_all(&normalized, r"<grn>+++ /nix/store/HASH-")
+        .to_string();
+
+    let re = regex::Regex::new(r"/nix/store/(<rev>)[a-z0-9]{32}(</rev>)-").unwrap();
+    re.replace_all(&normalized, r"/nix/store/<rev>HASH</rev>-")
+        .to_string()
+}
+
 // Normalize store paths and hashes for consistent snapshots
 fn normalize_nix_output(output: &str, store_dir: &str) -> String {
     // Replace custom store path with /nix/store
@@ -156,11 +179,10 @@ fn test_inline_highlight_snapshot() {
 
     assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let normalized = normalize_nix_output(&stdout, &nix_store_dir);
 
     // Render ANSI escapes as readable tokens so the snapshot shows
     // exactly where reverse-video begins/ends.
-    let readable = normalized
+    let readable = stdout
         .replace("\x1b[7m", "<rev>")
         .replace("\x1b[27m", "</rev>")
         .replace("\x1b[31m", "<red>")
@@ -171,9 +193,11 @@ fn test_inline_highlight_snapshot() {
         .replace("\x1b[2m", "<dim>")
         .replace("\x1b[0m", "</>");
 
+    let normalized = normalize_readable_nix_output(&readable, &nix_store_dir);
+
     assert!(
-        readable.contains("<rev>"),
+        normalized.contains("<rev>"),
         "expected reverse-video escapes for inline highlighting"
     );
-    assert_snapshot!(readable);
+    assert_snapshot!(normalized);
 }

--- a/tests/snapshots/snapshot_test__inline_highlight_snapshot.snap
+++ b/tests/snapshots/snapshot_test__inline_highlight_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/snapshot_test.rs
-expression: readable
+expression: normalized
 ---
 <red>--- /nix/store/HASH-hello-v1.drv</>
 <grn>+++ /nix/store/HASH-hello-v2.drv</>
@@ -9,23 +9,23 @@ expression: readable
           mkdir -p $out/bin</>
           cat > $out/bin/hello << 'EOF'</>
       #!/bin/sh</>
-    <red>- echo "Hello, World! <rev>v1"</rev></>
+    <red>- echo "Hello, World! <rev>v1</rev>"</>
     <grn>+ echo "Hello, World! <rev>v2"</rev></>
-    <grn>+ <rev>echo "Now with more features!"</rev></>
+    <grn>+ <rev>echo "Now with more features!</rev>"</>
       EOF</>
           chmod +x $out/bin/hello</>
       </>
           # Reference dependencies</>
-    <red>-     ln -s <rev>/nix/store/HASH-dep1/bin/dep1</rev> $out/bin/</>
-    <red>-     ln -s <rev>/nix/store/HASH-dep2/share</rev> $out/</>
-    <grn>+     ln -s <rev>/nix/store/HASH-dep1/bin/dep1</rev> $out/bin/</>
-    <grn>+     ln -s <rev>/nix/store/HASH-dep2/share</rev> $out/</>
+    <red>-     ln -s /nix/store/<rev>HASH</rev>-dep1/bin/dep1 $out/bin/</>
+    <red>-     ln -s /nix/store/<rev>HASH</rev>-dep2/share $out/</>
+    <grn>+     ln -s /nix/store/<rev>HASH</rev>-dep1/bin/dep1 $out/bin/</>
+    <grn>+     ln -s /nix/store/<rev>HASH</rev>-dep2/share $out/</>
 <b><cyn>• dep1.drv</>
   <b>Arguments:</>
     Argument 1:
         mkdir -p $out/bin && echo '#!/bin/sh</>
-      <red>- echo Dependency <rev>1'</rev> > $out/bin/dep1 && chmod +x $out/bin/dep1</>
-      <grn>+ echo Dependency <rev>1 updated'</rev> > $out/bin/dep1 && chmod +x $out/bin/dep1</>
+      <red>- echo Dependency 1' > $out/bin/dep1 && chmod +x $out/bin/dep1</>
+      <grn>+ echo Dependency 1<rev> updated</rev>' > $out/bin/dep1 && chmod +x $out/bin/dep1</>
 <b><cyn>• dep2.drv</>
   <b>Arguments:</>
     Argument 1:
@@ -37,11 +37,11 @@ expression: readable
       echo "Configuring environment"</>
     <grn>+ echo "Setting up new features"</>
       echo "Building dependencies"</>
-    <red>- echo "Compiling <rev>sources"</rev></>
-    <red>- echo "Running <rev>tests"</rev></>
-    <grn>+ echo "Compiling <rev>sources with optimizations"</rev></>
+    <red>- echo "Compiling sources"</>
+    <red>- echo "Running <rev>tests</rev>"</>
+    <grn>+ echo "Compiling sources<rev> with optimizations</rev>"</>
     <grn>+ echo "Running <rev>extended test suite"</rev></>
-    <grn>+ <rev>echo "Generating documentation"</rev></>
+    <grn>+ <rev>echo "Generating documentation</rev>"</>
       echo "Build complete!"</>
   description:
     <red>- A simple hello world program <rev>v1</rev></>


### PR DESCRIPTION
this provides more accurate and reliable inline highlighting inside
file path strings, or strings without whitespace splits.

this is especially helpful for quickly seeing that the only change to a
file path is its hash

example:

before:
<img width="1757" height="1346" alt="image" src="https://github.com/user-attachments/assets/17954093-3aa9-4a02-a12a-e114a6f8e251" />


after:
<img width="1779" height="1364" alt="image" src="https://github.com/user-attachments/assets/f9bc19cd-82ba-48fa-a3fb-c29ea9d002a8" />
