### PR TITLE
fix: resolve short flake attrs via packages/legacyPackages fallback

### DIFF
--- a/src/instantiate.rs
+++ b/src/instantiate.rs
@@ -61,10 +61,40 @@ fn instantiate_flake(flake_ref: &str, gcroot_path: &Path) -> Result<String> {
 
     let (store_path, nar_hash) = extract_flake_fields(&metadata_str)?;
 
-    // Create expression to evaluate the flake with narHash for pure evaluation
-    let expression = format!("(builtins.getFlake \"path:{store_path}?narHash={nar_hash}\").{attr}");
-
+    let expression = build_flake_expression(&store_path, &nar_hash, attr);
     instantiate_expression(&expression, gcroot_path)
+}
+
+/// Build a Nix expression that evaluates a flake attribute, mirroring the
+/// packages/legacyPackages resolution that `nix build` applies.
+///
+/// For a single-component attr like `samba`, this tries (in order):
+///   1. top-level output  (`f.samba`)
+///   2. `f.packages.<system>.samba`
+///   3. `f.legacyPackages.<system>.samba`
+///
+/// For a dotted attr like `packages.x86_64-linux.samba`, the path is used
+/// verbatim so callers can still address any output directly.
+fn build_flake_expression(store_path: &str, nar_hash: &str, attr: &str) -> String {
+    let flake_expr = format!("builtins.getFlake \"path:{store_path}?narHash={nar_hash}\"");
+
+    if attr.contains('.') {
+        // Fully-qualified path — use verbatim, as before.
+        format!("({flake_expr}).{attr}")
+    } else {
+        // Single-component: try top-level, then packages.<s>, then legacyPackages.<s>.
+        // The has-attr operator (`?`) with short-circuit `&&` ensures we never throw on
+        // a missing intermediate attribute; only the final `else throw` fires.
+        format!(
+            "let f = {flake_expr}; s = builtins.currentSystem; in \
+             if f ? {attr} then f.{attr} \
+             else if f ? packages && f.packages ? ${{s}} && f.packages.${{s}} ? {attr} \
+             then f.packages.${{s}}.{attr} \
+             else if f ? legacyPackages && f.legacyPackages ? ${{s}} && f.legacyPackages.${{s}} ? {attr} \
+             then f.legacyPackages.${{s}}.{attr} \
+             else throw \"attribute '{attr}' not found in flake\""
+        )
+    }
 }
 
 #[derive(serde::Deserialize)]
@@ -184,5 +214,32 @@ mod tests {
         let (p, h) = extract_flake_fields(json).unwrap();
         assert_eq!(p, "/nix/store/x");
         assert_eq!(h, "sha256-abc");
+    }
+
+    #[test]
+    fn build_flake_expression_single_attr_has_resolution_logic() {
+        let expr = build_flake_expression("/nix/store/x", "sha256-abc", "samba");
+        // Must contain all three fallback branches.
+        assert!(expr.contains("f ? samba"), "missing top-level check: {expr}");
+        assert!(expr.contains("f ? packages"), "missing packages branch: {expr}");
+        assert!(
+            expr.contains("f ? legacyPackages"),
+            "missing legacyPackages branch: {expr}"
+        );
+        assert!(expr.contains("builtins.currentSystem"), "missing system: {expr}");
+    }
+
+    #[test]
+    fn build_flake_expression_dotted_attr_is_verbatim() {
+        let expr = build_flake_expression("/nix/store/x", "sha256-abc", "packages.x86_64-linux.samba");
+        // Fully-qualified path must be embedded verbatim; no resolution wrapper.
+        assert!(
+            expr.contains("packages.x86_64-linux.samba"),
+            "dotted attr not verbatim: {expr}"
+        );
+        assert!(
+            !expr.contains("legacyPackages"),
+            "unexpected resolution logic for dotted attr: {expr}"
+        );
     }
 }

--- a/src/instantiate.rs
+++ b/src/instantiate.rs
@@ -61,10 +61,35 @@ fn instantiate_flake(flake_ref: &str, gcroot_path: &Path) -> Result<String> {
 
     let (store_path, nar_hash) = extract_flake_fields(&metadata_str)?;
 
-    // Create expression to evaluate the flake with narHash for pure evaluation
-    let expression = format!("(builtins.getFlake \"path:{store_path}?narHash={nar_hash}\").{attr}");
-
+    let expression = build_flake_expression(&store_path, &nar_hash, attr);
     instantiate_expression(&expression, gcroot_path)
+}
+
+/// Build a Nix expression that evaluates a flake attribute, mirroring the
+/// packages/legacyPackages resolution that `nix build` applies.
+///
+/// For any attr — single-component (`samba`) or dotted (`foo.unwrapped`) —
+/// this tries in order:
+///   1. top-level output  (`f.<attr>`)
+///   2. `f.packages.<system>.<attr>`
+///   3. `f.legacyPackages.<system>.<attr>`
+///
+/// The has-attr operator (`?`) accepts dotted attrpaths and returns false
+/// rather than throwing when any intermediate attribute is missing, so
+/// fully-qualified attrs like `packages.x86_64-linux.samba` are handled
+/// correctly by branch 1 without a separate code path.
+fn build_flake_expression(store_path: &str, nar_hash: &str, attr: &str) -> String {
+    let flake_expr = format!("builtins.getFlake \"path:{store_path}?narHash={nar_hash}\"");
+
+    format!(
+        "let f = {flake_expr}; s = builtins.currentSystem; in \
+         if f ? {attr} then f.{attr} \
+         else if f ? packages && f.packages ? ${{s}} && f.packages.${{s}} ? {attr} \
+         then f.packages.${{s}}.{attr} \
+         else if f ? legacyPackages && f.legacyPackages ? ${{s}} && f.legacyPackages.${{s}} ? {attr} \
+         then f.legacyPackages.${{s}}.{attr} \
+         else throw \"attribute '{attr}' not found in flake\""
+    )
 }
 
 #[derive(serde::Deserialize)]
@@ -184,5 +209,33 @@ mod tests {
         let (p, h) = extract_flake_fields(json).unwrap();
         assert_eq!(p, "/nix/store/x");
         assert_eq!(h, "sha256-abc");
+    }
+
+    #[test]
+    fn build_flake_expression_single_attr_has_resolution_logic() {
+        let expr = build_flake_expression("/nix/store/x", "sha256-abc", "samba");
+        // Must contain all three fallback branches.
+        assert!(expr.contains("f ? samba"), "missing top-level check: {expr}");
+        assert!(expr.contains("f ? packages"), "missing packages branch: {expr}");
+        assert!(
+            expr.contains("f ? legacyPackages"),
+            "missing legacyPackages branch: {expr}"
+        );
+        assert!(expr.contains("builtins.currentSystem"), "missing system: {expr}");
+    }
+
+    #[test]
+    fn build_flake_expression_dotted_attr_has_resolution_logic() {
+        // Dotted attrs like `foo.unwrapped` or `packages.x86_64-linux.samba`
+        // must also go through resolution — the top-level `f ? <attr>` branch
+        // handles the already-qualified case without a separate code path.
+        let expr = build_flake_expression("/nix/store/x", "sha256-abc", "foo.unwrapped");
+        assert!(expr.contains("f ? foo.unwrapped"), "missing top-level check: {expr}");
+        assert!(expr.contains("f ? packages"), "missing packages branch: {expr}");
+        assert!(expr.contains("f ? legacyPackages"), "missing legacyPackages branch: {expr}");
+        // A fully-qualified path works the same way; f ? packages.x86_64-linux.samba
+        // will succeed in branch 1 so branches 2 and 3 are never reached.
+        let expr2 = build_flake_expression("/nix/store/x", "sha256-abc", "packages.x86_64-linux.samba");
+        assert!(expr2.contains("f ? packages.x86_64-linux.samba"), "missing top-level check: {expr2}");
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -141,3 +141,39 @@ fn test_flake_diff() {
 
     assert_diff_output(&stdout);
 }
+
+#[test]
+fn test_flake_diff_short_attr() {
+    let tests_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let (_nix_root, env_vars) = setup_nix_env();
+
+    // Use the short-form `#default` (no system prefix) — this exercises the
+    // packages/legacyPackages resolution added to fix issue #102.
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_nix-diff"));
+    cmd.args([
+        &format!(
+            "path:{}#default",
+            tests_dir.join("hello-flake-v1").to_str().unwrap()
+        ),
+        &format!(
+            "path:{}#default",
+            tests_dir.join("hello-flake-v2").to_str().unwrap()
+        ),
+    ])
+    .env("NO_COLOR", "1");
+    for (key, value) in &env_vars {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().expect("Failed to run nix-diff");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if output.status.code() != Some(1) {
+        eprintln!("nix-diff exited with {:?}, stderr: {stderr}", output.status);
+        eprintln!("stdout: {stdout}");
+        panic!("expected exit code 1 (differs)");
+    }
+
+    assert_diff_output(&stdout);
+}


### PR DESCRIPTION
Flake references like `.#samba` or `nixpkgs#samba` failed because the generated Nix expression accessed the attribute at the flake output's top level (e.g. `(builtins.getFlake ...).samba`).  For nixpkgs and most real flakes the package lives under `packages.<system>.<name>` or `legacyPackages.<system>.<name>`, so the lookup always threw "attribute missing".

Fix: for single-component attributes, `build_flake_expression` now generates an if/else chain that mirrors `nix build`'s resolution order: top-level -> `packages.<currentSystem>.<attr>` -> `legacyPackages.<currentSystem>.<attr>.` Dotted (fully-qualified) attribute paths are still passed verbatim.

Fixes #102.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
